### PR TITLE
[ISSUE 3] ToggleSwitchに視覚的なラベルテキストを追加

### DIFF
--- a/src/components/ToggleSwitch/ToggleSwitch.tsx
+++ b/src/components/ToggleSwitch/ToggleSwitch.tsx
@@ -6,20 +6,23 @@ type Props = {
 
 export function ToggleSwitch({ label, checked, onChange }: Props) {
   return (
-    <button
-      role="switch"
-      aria-checked={checked}
-      aria-label={label}
-      onClick={onChange}
-      className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors duration-300 ${
-        checked ? 'bg-casino-gold' : 'bg-gray-600'
-      }`}
-    >
-      <span
-        className={`inline-block h-4 w-4 rounded-full bg-white transition-transform duration-300 ${
-          checked ? 'translate-x-6' : 'translate-x-1'
+    <label className="flex items-center gap-1.5">
+      <span className="text-xs text-gray-400">{label}</span>
+      <button
+        role="switch"
+        aria-checked={checked}
+        aria-label={label}
+        onClick={onChange}
+        className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors duration-300 ${
+          checked ? 'bg-casino-gold' : 'bg-gray-600'
         }`}
-      />
-    </button>
+      >
+        <span
+          className={`inline-block h-4 w-4 rounded-full bg-white transition-transform duration-300 ${
+            checked ? 'translate-x-6' : 'translate-x-1'
+          }`}
+        />
+      </button>
+    </label>
   );
 }


### PR DESCRIPTION
https://claude.ai/code/session_01SbkKL9y7yWR7tcK3XpN5TN

## 概要

ToggleSwitch コンポーネントは aria-label のみでラベルを設定しており、視覚的なテキストが一切表示されていなかった。ヘッダー右側にスイッチが2つ並んでいるだけで、何のスイッチか判別不能。

## 変更種別

- [ ] `feat:` 新機能
- [x] `fix:` バグ修正
- [ ] `refactor:` リファクタリング
- [ ] `docs:` ドキュメント
- [ ] `style:` コードスタイル（動作に影響しない変更）
- [ ] `test:` テストの追加・修正
- [ ] `chore:` ビルド・CI・依存関係などの変更

## 変更内容

修正内容 (src/components/ToggleSwitch/ToggleSwitch.tsx):

- <label> 要素でスイッチを囲み、左側にラベルテキスト（text-xs text-gray-400）を表示
- 「ダークモード」「サウンド」のテキストがスイッチの横に常に見える状態に
- aria-label は引き続き維持し、アクセシビリティも保持

## 関連 Issue

closes #3

## スクリーンショット

<!-- UI変更がある場合はスクリーンショットを添付してください -->

## テスト

- [ ] 既存のテストが通ることを確認した
- [ ] 必要に応じて新しいテストを追加した

## チェックリスト

- [ ] `pnpm check` が通ることを確認した
- [ ] セルフレビューを実施した
- [ ] 破壊的変更がある場合、その影響を記載した
