### PR TITLE
[ISSUE 8] ヘッダーのタイトル折り返しを修正しスイッチラベルをアイコンに変更

### DIFF
--- a/src/components/GlobalHeader/GlobalHeader.tsx
+++ b/src/components/GlobalHeader/GlobalHeader.tsx
@@ -15,15 +15,19 @@ export function GlobalHeader({
 }: Props) {
   return (
     <header className="flex items-center justify-between px-4 py-3">
-      <h1 className="text-lg font-bold text-casino-gold">🪙 Coin Toss Game</h1>
-      <div className="flex items-center gap-3">
+      <h1 className="min-w-0 truncate text-lg font-bold text-casino-gold">
+        🪙 Coin Toss Game
+      </h1>
+      <div className="flex shrink-0 items-center gap-2">
         <ToggleSwitch
           label="ダークモード"
+          icon="🌙"
           checked={darkMode}
           onChange={onToggleDarkMode}
         />
         <ToggleSwitch
           label="サウンド"
+          icon="🔊"
           checked={soundEnabled}
           onChange={onToggleSound}
         />

--- a/src/components/ToggleSwitch/ToggleSwitch.tsx
+++ b/src/components/ToggleSwitch/ToggleSwitch.tsx
@@ -1,13 +1,18 @@
+import type { ReactNode } from 'react';
+
 type Props = {
   label: string;
+  icon: ReactNode;
   checked: boolean;
   onChange: () => void;
 };
 
-export function ToggleSwitch({ label, checked, onChange }: Props) {
+export function ToggleSwitch({ label, icon, checked, onChange }: Props) {
   return (
-    <label className="flex items-center gap-1.5">
-      <span className="text-xs text-gray-400">{label}</span>
+    <label className="flex items-center gap-1">
+      <span className="text-sm text-gray-400" aria-hidden="true">
+        {icon}
+      </span>
       <button
         role="switch"
         aria-checked={checked}


### PR DESCRIPTION
## 概要

<!-- このPRで行った変更の概要を簡潔に記載してください -->
Issue #3で追加したテキストラベルが横幅を取りすぎ、モバイル画面で
ヘッダータイトルが折り返される問題を修正。

## 変更種別

- [ ] `feat:` 新機能
- [x] `fix:` バグ修正
- [ ] `refactor:` リファクタリング
- [ ] `docs:` ドキュメント
- [ ] `style:` コードスタイル（動作に影響しない変更）
- [ ] `test:` テストの追加・修正
- [ ] `chore:` ビルド・CI・依存関係などの変更

## 変更内容

<!-- 具体的な変更内容を箇条書きで記載してください -->

- ToggleSwitchのテキストラベルをアイコン（🌙/🔊）に置き換え省スペース化
- タイトルにtruncateを追加し折り返しを防止
- スイッチコンテナにshrink-0を追加し縮小を防止


## 関連 Issue

<!-- 関連するIssueがあればリンクしてください（例: closes #123） -->

closes #8

## スクリーンショット

<!-- UI変更がある場合はスクリーンショットを添付してください -->

## テスト

- [ ] 既存のテストが通ることを確認した
- [ ] 必要に応じて新しいテストを追加した

## チェックリスト

- [ ] `pnpm check` が通ることを確認した
- [ ] セルフレビューを実施した
- [ ] 破壊的変更がある場合、その影響を記載した

https://claude.ai/code/session_01SbkKL9y7yWR7tcK3XpN5TN