### PR TITLE
[ISSUE 11] 10回モードにも途中で止めるボタンを追加

### DIFF
--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useState } from 'react';
 import { useNavigate, useParams, Navigate } from 'react-router-dom';
 import type { GameMode } from '@/consts/game';
-import { GAME_MODES, SCORE_UNITS } from '@/consts/game';
+import { SCORE_UNITS } from '@/consts/game';
 import { GameModeSchema } from '@/features/game/game.schema';
 import { useGameLogic } from '@/features/game/useGameLogic';
 import { useGameStorage } from '@/features/storage/useGameStorage';
@@ -138,14 +138,14 @@ function GamePageContent({ mode }: ContentProps) {
           </div>
         )}
 
-        {mode === GAME_MODES.survival && state.phase === 'ready' && (
+        {state.phase === 'ready' && (
           <div className="flex justify-center py-4">
             <Button
               onClick={handleGiveUp}
               variant="secondary"
               className="text-sm"
             >
-              ギブアップ
+              やめる
             </Button>
           </div>
         )}
@@ -153,7 +153,7 @@ function GamePageContent({ mode }: ContentProps) {
 
       <Modal open={showGiveUpModal} onClose={handleGiveUpCancel}>
         <h2 className="mb-4 text-center text-lg font-bold text-amber-700 dark:text-casino-gold">
-          ギブアップしますか？
+          ゲームを終了しますか？
         </h2>
         <p className="mb-6 text-center text-sm text-gray-600 dark:text-gray-400">
           {`現在のスコア: ${state.score}${SCORE_UNITS[mode]}`}


### PR DESCRIPTION
## 概要

Issue #11 の対応として、10回モードにも途中でゲームを止めるボタンを追加しました。これにより、10回モードでもユーザーが途中で離脱したい場合に、スコアを保存して結果画面に遷移できるようになります。

## 変更種別

- [x] `feat:` 新機能

## 変更内容

- 「やめる」ボタンを10回モードとサバイバルモード両方で表示するよう変更（従来はサバイバルモードのみ）
- ボタンのラベルを「やめる」に統一
- モーダルのヘッダーテキストを「ゲームを終了しますか？」に変更（従来の「ギブアップしますか？」から変更）
- 不要な`GAME_MODES`インポートを削除

## 関連 Issue

closes #11

## スクリーンショット

UI変更があるため、ローカル環境で`pnpm dev`を実行して以下を確認してください：
- 10回モードで「やめる」ボタンが表示されること
- ボタンクリック時にモーダルが表示されること
- モーダルで「終了する」を選択すると結果画面に遷移すること

## テスト

- [x] 既存のテストが通ることを確認した（全61テスト通過）
- [x] 必要に応じて新しいテストを追加した（既存テストで十分カバー）

## チェックリスト

- [x] `pnpm check` が通ることを確認した（type-check, lint, test全て通過）
- [x] セルフレビューを実施した
- [x] 破壊的変更がある場合、その影響を記載した（破壊的変更なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)