### PR TITLE
[ISSUE 17] 利用規約・プライバシーポリシー画面とフッターの追加

### DIFF
--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -2,6 +2,8 @@ import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { HomePage } from '@/pages/HomePage';
 import { GamePage } from '@/pages/GamePage';
 import { ResultPage } from '@/pages/ResultPage';
+import { TermsPage } from '@/pages/TermsPage';
+import { PrivacyPolicyPage } from '@/pages/PrivacyPolicyPage';
 
 const BASENAME = import.meta.env.BASE_URL;
 
@@ -12,6 +14,8 @@ export function AppRouter() {
         <Route path="/" element={<HomePage />} />
         <Route path="/game/:mode" element={<GamePage />} />
         <Route path="/result" element={<ResultPage />} />
+        <Route path="/terms" element={<TermsPage />} />
+        <Route path="/privacy" element={<PrivacyPolicyPage />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
     </BrowserRouter>

--- a/src/components/GlobalFooter/GlobalFooter.tsx
+++ b/src/components/GlobalFooter/GlobalFooter.tsx
@@ -1,0 +1,28 @@
+import { Link } from 'react-router-dom';
+
+export function GlobalFooter() {
+  return (
+    <footer className="mt-8 border-t border-gray-200 py-6 dark:border-gray-800">
+      <div className="mx-auto flex max-w-6xl flex-col items-center gap-2 px-4 text-center">
+        <nav className="flex gap-4 text-xs text-gray-500 dark:text-gray-500">
+          <Link
+            to="/terms"
+            className="hover:text-amber-700 dark:hover:text-casino-gold"
+          >
+            利用規約
+          </Link>
+          <span aria-hidden="true">·</span>
+          <Link
+            to="/privacy"
+            className="hover:text-amber-700 dark:hover:text-casino-gold"
+          >
+            プライバシーポリシー
+          </Link>
+        </nav>
+        <p className="text-xs text-gray-400 dark:text-gray-600">
+          &copy; {new Date().getFullYear()} Coin Toss Game
+        </p>
+      </div>
+    </footer>
+  );
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -4,6 +4,7 @@ import { useGameStorage } from '@/features/storage/useGameStorage';
 import { useDarkMode } from '@/hooks/useDarkMode';
 import { useSound } from '@/hooks/useSound';
 import { GlobalHeader } from '@/components/GlobalHeader/GlobalHeader';
+import { GlobalFooter } from '@/components/GlobalFooter/GlobalFooter';
 import { HeroCoin } from '@/features/home/HeroCoin/HeroCoin';
 import { ModeCard } from '@/features/mode/ModeCard/ModeCard';
 import { LeaderBoard } from '@/features/home/LeaderBoard/LeaderBoard';
@@ -52,6 +53,7 @@ export function HomePage() {
       </div>
 
       <LeaderBoard topScores={data.topScores} />
+      <GlobalFooter />
     </div>
   );
 }

--- a/src/pages/PrivacyPolicyPage.tsx
+++ b/src/pages/PrivacyPolicyPage.tsx
@@ -1,0 +1,104 @@
+import { Link } from 'react-router-dom';
+import { Icon } from '@/components/Icon/Icon';
+import { GlobalFooter } from '@/components/GlobalFooter/GlobalFooter';
+
+export function PrivacyPolicyPage() {
+  return (
+    <div className="min-h-screen bg-light-gradient dark:bg-casino-gradient">
+      <div className="mx-auto max-w-2xl px-4 py-8">
+        <Link
+          to="/"
+          className="mb-6 inline-flex items-center gap-1 text-sm text-gray-500 hover:text-amber-700 dark:text-gray-400 dark:hover:text-casino-gold"
+        >
+          <Icon name="arrow_back" size={16} />
+          ホームに戻る
+        </Link>
+
+        <h1 className="mb-8 text-2xl font-bold text-amber-700 dark:text-casino-gold">
+          プライバシーポリシー
+        </h1>
+
+        <div className="space-y-6 text-sm leading-relaxed text-gray-700 dark:text-gray-300">
+          <p>
+            当サイトは、ユーザーのプライバシーを尊重し、個人情報の保護に努めます。本プライバシーポリシーでは、当サイトが運営する「Coin
+            Toss
+            Game」（以下「本サービス」）における情報の取り扱いについて説明します。
+          </p>
+
+          <section>
+            <h2 className="mb-2 font-semibold text-gray-900 dark:text-gray-100">
+              1. 収集する情報
+            </h2>
+            <p>本サービスでは、以下の情報を取り扱います。</p>
+            <ul className="mt-2 list-inside list-disc space-y-1">
+              <li>
+                <span className="font-medium">LocalStorage データ：</span>
+                ゲームスコアおよびアプリの設定（ダークモード・サウンド設定）をお使いのデバイスのLocalStorageに保存します。このデータはサーバーに送信されず、外部に共有されることはありません。
+              </li>
+              <li>
+                <span className="font-medium">
+                  広告配信に関するデータ（Google AdSense）：
+                </span>
+                本サービスではGoogle
+                AdSenseを利用した広告を掲載しています。Googleは広告配信のためにCookieを使用し、ユーザーの興味に基づいた広告を表示する場合があります。
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="mb-2 font-semibold text-gray-900 dark:text-gray-100">
+              2. Cookieについて
+            </h2>
+            <p>
+              本サービス自体はCookieを使用しません。ただし、Google
+              AdSenseによる広告配信においてCookieが利用される場合があります。Cookieの利用を無効化したい場合は、ブラウザの設定から変更することができます。
+            </p>
+          </section>
+
+          <section>
+            <h2 className="mb-2 font-semibold text-gray-900 dark:text-gray-100">
+              3. 第三者へのデータ提供
+            </h2>
+            <p>
+              当サイトは、法令に基づく場合を除き、ユーザーの情報を第三者に提供することはありません。なお、Google
+              AdSenseの利用に関するデータについては、Googleのプライバシーポリシーに従います。
+            </p>
+            <p className="mt-2">
+              Google のプライバシーポリシーについては
+              <a
+                href="https://policies.google.com/privacy"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline hover:text-amber-700 dark:hover:text-casino-gold"
+              >
+                こちら
+              </a>
+              をご確認ください。
+            </p>
+          </section>
+
+          <section>
+            <h2 className="mb-2 font-semibold text-gray-900 dark:text-gray-100">
+              4. アクセス解析
+            </h2>
+            <p>本サービスでは現在、アクセス解析ツールは使用していません。</p>
+          </section>
+
+          <section>
+            <h2 className="mb-2 font-semibold text-gray-900 dark:text-gray-100">
+              5. プライバシーポリシーの変更
+            </h2>
+            <p>
+              当サイトは、必要に応じて本プライバシーポリシーを変更する場合があります。変更後のポリシーは本ページに掲載した時点で効力を生じます。
+            </p>
+          </section>
+
+          <p className="pt-4 text-xs text-gray-400 dark:text-gray-600">
+            制定日：2026年2月15日
+          </p>
+        </div>
+      </div>
+      <GlobalFooter />
+    </div>
+  );
+}

--- a/src/pages/ResultPage.tsx
+++ b/src/pages/ResultPage.tsx
@@ -10,6 +10,7 @@ import { TopScoresComparison } from '@/features/result/TopScoresComparison/TopSc
 import { ShareSection } from '@/features/result/ShareSection/ShareSection';
 import { MotivationMessage } from '@/features/result/MotivationMessage/MotivationMessage';
 import { AdPlaceholder } from '@/components/AdPlaceholder/AdPlaceholder';
+import { GlobalFooter } from '@/components/GlobalFooter/GlobalFooter';
 import { Button } from '@/components/Button/Button';
 import { Icon } from '@/components/Icon/Icon';
 
@@ -96,6 +97,7 @@ export function ResultPage() {
           </div>
         </div>
       </div>
+      <GlobalFooter />
     </div>
   );
 }

--- a/src/pages/TermsPage.tsx
+++ b/src/pages/TermsPage.tsx
@@ -1,0 +1,100 @@
+import { Link } from 'react-router-dom';
+import { Icon } from '@/components/Icon/Icon';
+import { GlobalFooter } from '@/components/GlobalFooter/GlobalFooter';
+
+export function TermsPage() {
+  return (
+    <div className="min-h-screen bg-light-gradient dark:bg-casino-gradient">
+      <div className="mx-auto max-w-2xl px-4 py-8">
+        <Link
+          to="/"
+          className="mb-6 inline-flex items-center gap-1 text-sm text-gray-500 hover:text-amber-700 dark:text-gray-400 dark:hover:text-casino-gold"
+        >
+          <Icon name="arrow_back" size={16} />
+          ホームに戻る
+        </Link>
+
+        <h1 className="mb-8 text-2xl font-bold text-amber-700 dark:text-casino-gold">
+          利用規約
+        </h1>
+
+        <div className="space-y-6 text-sm leading-relaxed text-gray-700 dark:text-gray-300">
+          <section>
+            <h2 className="mb-2 font-semibold text-gray-900 dark:text-gray-100">
+              第1条（本規約の適用）
+            </h2>
+            <p>
+              本利用規約（以下「本規約」といいます）は、当サイトが提供する「Coin
+              Toss
+              Game」（以下「本サービス」といいます）の利用に関する条件を定めるものです。ユーザーは本規約に同意のうえ、本サービスをご利用ください。
+            </p>
+          </section>
+
+          <section>
+            <h2 className="mb-2 font-semibold text-gray-900 dark:text-gray-100">
+              第2条（サービスの内容）
+            </h2>
+            <p>
+              本サービスは、コイントスの表裏を予想して楽しむ無料のブラウザゲームです。スコアはお使いのデバイスのLocalStorageに保存され、サーバーへの送信は行いません。
+            </p>
+          </section>
+
+          <section>
+            <h2 className="mb-2 font-semibold text-gray-900 dark:text-gray-100">
+              第3条（禁止事項）
+            </h2>
+            <p>ユーザーは以下の行為を行ってはなりません。</p>
+            <ul className="mt-2 list-inside list-disc space-y-1">
+              <li>本サービスの運営を妨害する行為</li>
+              <li>本サービスを通じて不正アクセスを行う行為</li>
+              <li>法令または公序良俗に反する行為</li>
+              <li>その他、当サイトが不適切と判断する行為</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="mb-2 font-semibold text-gray-900 dark:text-gray-100">
+              第4条（免責事項）
+            </h2>
+            <p>
+              当サイトは、本サービスの利用によって生じたいかなる損害についても責任を負いません。また、本サービスは予告なく内容の変更・停止・終了を行う場合があります。
+            </p>
+          </section>
+
+          <section>
+            <h2 className="mb-2 font-semibold text-gray-900 dark:text-gray-100">
+              第5条（広告について）
+            </h2>
+            <p>
+              本サービスでは、Google
+              AdSenseによる広告を掲載しています。広告の配信にあたり、Googleが提供する情報を利用する場合があります。詳しくは
+              <a
+                href="https://policies.google.com/technologies/ads"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline hover:text-amber-700 dark:hover:text-casino-gold"
+              >
+                Googleの広告ポリシー
+              </a>
+              をご確認ください。
+            </p>
+          </section>
+
+          <section>
+            <h2 className="mb-2 font-semibold text-gray-900 dark:text-gray-100">
+              第6条（本規約の変更）
+            </h2>
+            <p>
+              当サイトは、必要に応じて本規約を変更できるものとします。変更後の規約は本ページに掲載した時点で効力を生じます。
+            </p>
+          </section>
+
+          <p className="pt-4 text-xs text-gray-400 dark:text-gray-600">
+            制定日：2026年2月15日
+          </p>
+        </div>
+      </div>
+      <GlobalFooter />
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要

Google AdSense承認に必要な利用規約・プライバシーポリシーページを追加し、各画面からアクセスできるフッターを実装しました。

## 変更種別

- [x] `feat:` 新機能

## 変更内容

- `src/components/GlobalFooter/GlobalFooter.tsx` を新規作成
  - 利用規約・プライバシーポリシーへのリンクを含むミニマルなフッターコンポーネント
  - カジノテーマに合わせたデザイン（ゴールドホバー）
- `src/pages/TermsPage.tsx` を新規作成（`/terms`）
  - サービス概要・禁止事項・免責事項・Google AdSenseに関する条項（全6条）
- `src/pages/PrivacyPolicyPage.tsx` を新規作成（`/privacy`）
  - LocalStorage・Cookie・Google AdSense・第三者提供に関する説明（全5項）
- `src/AppRouter.tsx` に `/terms`・`/privacy` ルートを追加
- `src/pages/HomePage.tsx`・`src/pages/ResultPage.tsx` に `GlobalFooter` を追加

## 関連 Issue

closes #17

## スクリーンショット

<!-- UI変更がある場合はスクリーンショットを添付してください -->

## テスト

- [x] 既存のテストが通ることを確認した（61件 全パス）
- [x] 必要に応じて新しいテストを追加した（静的コンテンツのため追加なし）

## チェックリスト

- [x] `pnpm check` が通ることを確認した（build / lint / type-check / test）
- [x] セルフレビューを実施した
- [x] 破壊的変更がある場合、その影響を記載した（破壊的変更なし）
