### PR TITLE
[ISSUE 19] ページ遅延読み込みとローディングUIを追加

### DIFF
--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -1,3 +1,4 @@
+import { lazy, Suspense } from 'react';
 import {
   createBrowserRouter,
   RouterProvider,
@@ -5,17 +6,33 @@ import {
   ScrollRestoration,
   Navigate,
 } from 'react-router-dom';
-import { HomePage } from '@/pages/HomePage';
-import { GamePage } from '@/pages/GamePage';
-import { ResultPage } from '@/pages/ResultPage';
-import { TermsPage } from '@/pages/TermsPage';
-import { PrivacyPolicyPage } from '@/pages/PrivacyPolicyPage';
+import { PageLoader } from '@/components/PageLoader/PageLoader';
+
+const HomePage = lazy(() =>
+  import('@/pages/HomePage').then((m) => ({ default: m.HomePage })),
+);
+const GamePage = lazy(() =>
+  import('@/pages/GamePage').then((m) => ({ default: m.GamePage })),
+);
+const ResultPage = lazy(() =>
+  import('@/pages/ResultPage').then((m) => ({ default: m.ResultPage })),
+);
+const TermsPage = lazy(() =>
+  import('@/pages/TermsPage').then((m) => ({ default: m.TermsPage })),
+);
+const PrivacyPolicyPage = lazy(() =>
+  import('@/pages/PrivacyPolicyPage').then((m) => ({
+    default: m.PrivacyPolicyPage,
+  })),
+);
 
 function RootLayout() {
   return (
     <>
       <ScrollRestoration />
-      <Outlet />
+      <Suspense fallback={<PageLoader />}>
+        <Outlet />
+      </Suspense>
     </>
   );
 }

--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -8,11 +8,29 @@ import {
 } from 'react-router-dom';
 import { PageLoader } from '@/components/PageLoader/PageLoader';
 
-const HomePage = lazy(() => import('@/pages/HomePage'));
-const GamePage = lazy(() => import('@/pages/GamePage'));
-const ResultPage = lazy(() => import('@/pages/ResultPage'));
-const TermsPage = lazy(() => import('@/pages/TermsPage'));
-const PrivacyPolicyPage = lazy(() => import('@/pages/PrivacyPolicyPage'));
+const minDelay = <T,>(promise: Promise<T>, ms: number) =>
+  Promise.all([
+    promise,
+    new Promise<void>((resolve) => setTimeout(resolve, ms)),
+  ]).then(([module]) => module);
+
+const MIN_LOADING_TIME_MS = 2000;
+
+const HomePage = lazy(() =>
+  minDelay(import('@/pages/HomePage'), MIN_LOADING_TIME_MS),
+);
+const GamePage = lazy(() =>
+  minDelay(import('@/pages/GamePage'), MIN_LOADING_TIME_MS),
+);
+const ResultPage = lazy(() =>
+  minDelay(import('@/pages/ResultPage'), MIN_LOADING_TIME_MS),
+);
+const TermsPage = lazy(() =>
+  minDelay(import('@/pages/TermsPage'), MIN_LOADING_TIME_MS),
+);
+const PrivacyPolicyPage = lazy(() =>
+  minDelay(import('@/pages/PrivacyPolicyPage'), MIN_LOADING_TIME_MS),
+);
 
 function RootLayout() {
   return (

--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -8,23 +8,11 @@ import {
 } from 'react-router-dom';
 import { PageLoader } from '@/components/PageLoader/PageLoader';
 
-const HomePage = lazy(() =>
-  import('@/pages/HomePage').then((m) => ({ default: m.HomePage })),
-);
-const GamePage = lazy(() =>
-  import('@/pages/GamePage').then((m) => ({ default: m.GamePage })),
-);
-const ResultPage = lazy(() =>
-  import('@/pages/ResultPage').then((m) => ({ default: m.ResultPage })),
-);
-const TermsPage = lazy(() =>
-  import('@/pages/TermsPage').then((m) => ({ default: m.TermsPage })),
-);
-const PrivacyPolicyPage = lazy(() =>
-  import('@/pages/PrivacyPolicyPage').then((m) => ({
-    default: m.PrivacyPolicyPage,
-  })),
-);
+const HomePage = lazy(() => import('@/pages/HomePage'));
+const GamePage = lazy(() => import('@/pages/GamePage'));
+const ResultPage = lazy(() => import('@/pages/ResultPage'));
+const TermsPage = lazy(() => import('@/pages/TermsPage'));
+const PrivacyPolicyPage = lazy(() => import('@/pages/PrivacyPolicyPage'));
 
 function RootLayout() {
   return (

--- a/src/components/PageLoader/PageLoader.tsx
+++ b/src/components/PageLoader/PageLoader.tsx
@@ -1,10 +1,32 @@
 import { memo } from 'react';
+import { motion } from 'framer-motion';
+import { Icon } from '@/components/Icon/Icon';
+
+const COIN_ROTATE = {
+  rotateY: [0, 1800, 3600],
+  scale: [1, 1.15, 1],
+};
+
+const COIN_TRANSITION = {
+  duration: 3.5,
+  ease: 'easeInOut' as const,
+  repeat: Infinity,
+};
 
 export const PageLoader = memo(function PageLoader() {
   return (
     <div className="flex min-h-screen items-center justify-center bg-light-gradient dark:bg-casino-gradient">
       <div className="flex flex-col items-center gap-4">
-        <div className="h-12 w-12 animate-spin rounded-full border-4 border-amber-200 border-t-amber-600 dark:border-casino-gray dark:border-t-casino-gold" />
+        <motion.div
+          animate={COIN_ROTATE}
+          transition={COIN_TRANSITION}
+          className="flex h-14 w-14 items-center justify-center rounded-full bg-yellow-400"
+          style={{
+            perspective: 1000,
+          }}
+        >
+          <Icon name="monetization_on" size={40} className="text-white" />
+        </motion.div>
         <p className="text-sm text-amber-700 dark:text-casino-gold">
           読み込み中...
         </p>

--- a/src/components/PageLoader/PageLoader.tsx
+++ b/src/components/PageLoader/PageLoader.tsx
@@ -1,0 +1,14 @@
+import { memo } from 'react';
+
+export const PageLoader = memo(function PageLoader() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-light-gradient dark:bg-casino-gradient">
+      <div className="flex flex-col items-center gap-4">
+        <div className="h-12 w-12 animate-spin rounded-full border-4 border-amber-200 border-t-amber-600 dark:border-casino-gray dark:border-t-casino-gold" />
+        <p className="text-sm text-amber-700 dark:text-casino-gold">
+          読み込み中...
+        </p>
+      </div>
+    </div>
+  );
+});

--- a/src/features/result/ShareSection/ShareSection.tsx
+++ b/src/features/result/ShareSection/ShareSection.tsx
@@ -46,6 +46,7 @@ export function ShareSection({
 
   const handleShareLine = useCallback(async () => {
     try {
+      await liffService.init();
       await liffService.shareTargetPicker(shareText);
     } catch {
       window.open(

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -18,7 +18,7 @@ import { ResultFeedback } from '@/features/game/ResultFeedback/ResultFeedback';
 import { StreakNotification } from '@/features/game/StreakNotification/StreakNotification';
 import type { GameResult } from '@/features/result/result.schema';
 
-export function GamePage() {
+function GamePage() {
   const { mode: modeParam } = useParams<{ mode: string }>();
   const parsed = GameModeSchema.safeParse(modeParam);
 
@@ -178,3 +178,5 @@ function GamePageContent({ mode }: ContentProps) {
     </div>
   );
 }
+
+export default GamePage;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -10,7 +10,7 @@ import { ModeCard } from '@/features/mode/ModeCard/ModeCard';
 import { LeaderBoard } from '@/features/home/LeaderBoard/LeaderBoard';
 import { Icon } from '@/components/Icon/Icon';
 
-export function HomePage() {
+function HomePage() {
   const { data } = useGameStorage();
   const { darkMode, toggleDarkMode } = useDarkMode();
   const { soundEnabled, toggleSound } = useSound();
@@ -57,3 +57,5 @@ export function HomePage() {
     </div>
   );
 }
+
+export default HomePage;

--- a/src/pages/PrivacyPolicyPage.tsx
+++ b/src/pages/PrivacyPolicyPage.tsx
@@ -2,7 +2,7 @@ import { Link } from 'react-router-dom';
 import { Icon } from '@/components/Icon/Icon';
 import { GlobalFooter } from '@/components/GlobalFooter/GlobalFooter';
 
-export function PrivacyPolicyPage() {
+function PrivacyPolicyPage() {
   return (
     <div className="min-h-screen bg-light-gradient dark:bg-casino-gradient">
       <div className="mx-auto max-w-2xl px-4 py-8">
@@ -102,3 +102,5 @@ export function PrivacyPolicyPage() {
     </div>
   );
 }
+
+export default PrivacyPolicyPage;

--- a/src/pages/ResultPage.tsx
+++ b/src/pages/ResultPage.tsx
@@ -14,7 +14,7 @@ import { GlobalFooter } from '@/components/GlobalFooter/GlobalFooter';
 import { Button } from '@/components/Button/Button';
 import { Icon } from '@/components/Icon/Icon';
 
-export function ResultPage() {
+function ResultPage() {
   const location = useLocation();
   const navigate = useNavigate();
   const { data } = useGameStorage();
@@ -101,3 +101,5 @@ export function ResultPage() {
     </div>
   );
 }
+
+export default ResultPage;

--- a/src/pages/TermsPage.tsx
+++ b/src/pages/TermsPage.tsx
@@ -2,7 +2,7 @@ import { Link } from 'react-router-dom';
 import { Icon } from '@/components/Icon/Icon';
 import { GlobalFooter } from '@/components/GlobalFooter/GlobalFooter';
 
-export function TermsPage() {
+function TermsPage() {
   return (
     <div className="min-h-screen bg-light-gradient dark:bg-casino-gradient">
       <div className="mx-auto max-w-2xl px-4 py-8">
@@ -98,3 +98,5 @@ export function TermsPage() {
     </div>
   );
 }
+
+export default TermsPage;

--- a/src/services/liff.service.ts
+++ b/src/services/liff.service.ts
@@ -1,6 +1,9 @@
-import liff from '@line/liff';
+import type liff from '@line/liff';
+
+type Liff = typeof liff;
 
 class LiffService {
+  private liff: Liff | null = null;
   private initialized = false;
   private initializing = false;
 
@@ -21,7 +24,9 @@ class LiffService {
     this.initializing = true;
 
     try {
-      await liff.init({ liffId });
+      const { default: liffSdk } = await import('@line/liff');
+      await liffSdk.init({ liffId });
+      this.liff = liffSdk;
       this.initialized = true;
     } catch (error) {
       console.error('LIFF initialization error:', error);
@@ -31,16 +36,16 @@ class LiffService {
   }
 
   isInClient(): boolean {
-    return this.initialized && liff.isInClient();
+    return this.initialized && (this.liff?.isInClient() ?? false);
   }
 
   async shareTargetPicker(text: string): Promise<void> {
-    if (!this.isInClient()) {
+    if (!this.isInClient() || !this.liff) {
       throw new Error('Not in LIFF environment');
     }
 
     try {
-      await liff.shareTargetPicker([{ type: 'text', text }]);
+      await this.liff.shareTargetPicker([{ type: 'text', text }]);
     } catch (error) {
       console.error('LINE share error:', error);
       throw error;


### PR DESCRIPTION
## 概要

画面コンテンツの読み込み時にユーザーへローディング状態を伝えるUIを追加し、
低速回線環境でのブランク表示を解消します。
あわせてルートレベルのコード分割と LIFF SDK の遅延読み込みを実装し、
初回バンドルサイズを削減しました。

## 変更種別

- [x] `feat:` 新機能

## 変更内容

- `PageLoader` コンポーネントを新規作成（スピナー＋「読み込み中...」テキスト、カジノテーマ対応）
- `AppRouter.tsx` の全ページを `React.lazy()` + `Suspense` に変更し、ルートレベルのコード分割を実現
  - ページ遷移中・初回チャンク読み込み中に `PageLoader` がフォールバック表示される
- `liff.service.ts` の `@line/liff` 静的インポートを動的インポートに変更
  - LINE ブラウザ環境で `init()` が呼ばれたときのみ SDK（〜200KB+）を読み込む
- `ShareSection.tsx` の `handleShareLine` で `liffService.init()` を呼び出すよう修正
  - これまで初期化が一度も行われておらず、LIFF 経由シェアが常にフォールバック動作になっていたバグを修正
- Pageコンポーネントの記法を`export default`に変更
- ローディングスピナーをコインに変更し、最低2秒表示するように修正

## 関連 Issue

closes #19

## スクリーンショット

<!-- ローカル確認後に添付してください -->

## テスト

- [x] 既存のテストが通ることを確認した（61 tests passed）
- [ ] 必要に応じて新しいテストを追加した

## チェックリスト

- [x] `pnpm check` が通ることを確認した
- [x] セルフレビューを実施した
- [ ] 破壊的変更がある場合、その影響を記載した